### PR TITLE
Ensure ALL pushed commits are scanned and the default config is usable

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,11 +1,15 @@
 name: gitleaks
 
-on: [push,pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@master
+      - uses: actions/checkout@v1
+      - name: gitleaks-action with defaults
+        uses: zricethezav/gitleaks-action@master
+      - name: gitleaks-action with config
+        uses: zricethezav/gitleaks-action@master
+        with:
+          config-path: .gitleaks.yml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,6 @@ CONFIG=""
 # check if a custom config have been provided
 if [ -f "$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH" ]; then
   CONFIG=" --config-path=$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH"
-else
-  CONFIG=" --config-path=$GITHUB_WORKSPACE/.gitleaks.toml"
 fi
 
 echo running gitleaks "$(gitleaks --version) with the following command👇"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,8 @@ DONATE_MSG="👋 maintaining gitleaks takes a lot of work so consider sponsoring
 
 if [ "$GITHUB_EVENT_NAME" = "push" ]
 then
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commit=$GITHUB_SHA $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commit=$GITHUB_SHA $CONFIG)
+  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG
+  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG)
 elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]
 then 
   git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt


### PR DESCRIPTION
`v1.20` was working great for me, however I noticed if I bundled a few commits together and pushed, only the first one was scanned.  There is a performance hit for this, but I think this is basic functionality that you want to ensure works properly.

I also was throwing an error with fallback to the default config on `master`.  
> If the user doesn't have the config file present in their repo, things break down
I included a change to the if statement to address this.

It might be helpful to test the action works as expected both with, and without a custom config file.