### PR TITLE
Checks always passing regardless of leaks

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,14 +22,15 @@ then
   echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG
   CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG)
 fi
-echo "$CAPTURE_OUTPUT"
-echo "::set-output name=result::$CAPTURE_OUTPUT"
 
 if [ $? -eq 1 ]
 then
   GITLEAKS_RESULT=$(echo -e "\e[31m🛑 STOP! Gitleaks encountered leaks")
   echo "$GITLEAKS_RESULT"
   echo "::set-output name=exitcode::$GITLEAKS_RESULT"
+  echo "----------------------------------"
+  echo "$CAPTURE_OUTPUT"
+  echo "::set-output name=result::$CAPTURE_OUTPUT"
   echo "----------------------------------"
   echo -e $DONATE_MSG
   exit 1


### PR DESCRIPTION
Hi, amazing tool. Thank you for all the hard work.

I tried setting up gitleaks-action on a new repository through Github Actions and noticed that even where there are leaks, the check still passes. 

In `entrypoint.sh`, I think the exit code for the `gitleaks` command running on line 22 was not passed properly to the if statement below because of other commands in between. Thus, it was showing "SUCCESS! Your code is good to go!" all the time with a exit code of 0, regardless of whether there were leaks.

I moved the two lines in between the if statement so that the capture output is shown when there is a leak.