### PR TITLE
Limit commit range scanned on `push` events

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,12 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: gitleaks-action with defaults
-        # uses: zricethezav/gitleaks-action@master
-        uses: stone-z/gitleaks-action@scan-only-pushed-commits
+        uses: stone-z/gitleaks-action@limit-push-scan
         with:
           commit-before: ${{ github.event.before }}
       - name: gitleaks-action with config
-        uses: stone-z/gitleaks-action@scan-only-pushed-commits
+        uses: stone-z/gitleaks-action@limit-push-scan
         with:
           config-path: .gitleaks.yml
           commit-before: ${{ github.event.before }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,8 +8,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: gitleaks-action with defaults
-        uses: zricethezav/gitleaks-action@master
+        # uses: zricethezav/gitleaks-action@master
+        uses: stone-z/gitleaks-action@scan-only-pushed-commits
+        with:
+          commit-before: ${{ github.event.before }}
       - name: gitleaks-action with config
-        uses: zricethezav/gitleaks-action@master
+        uses: stone-z/gitleaks-action@scan-only-pushed-commits
         with:
           config-path: .gitleaks.yml
+          commit-before: ${{ github.event.before }}

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'Path to config (relative to $GITHUB_WORKSPACE)'
     required: false
     default: '.github/.gitleaks.toml'
+  commit-before:
+    description: 'SHA of the commit before the push.'
+    required: true
 outputs:
   result: # id of output
     description: 'Gitleaks log output'
@@ -18,3 +21,5 @@ runs:
   image: "Dockerfile"
   args:
     - ${{ inputs.config-path }}
+    - ${{ inputs.commit-before }}
+    

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,27 +1,31 @@
 #!/bin/bash
 
 INPUT_CONFIG_PATH="$1"
+INPUT_COMMIT_BEFORE="$2"
 CONFIG=""
 
-# check if a custom config have been provided
+# Check if a custom config has been provided.
 if [ -f "$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH" ]; then
   CONFIG=" --config-path=$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH"
 fi
 
-echo running gitleaks "$(gitleaks --version) with the following command👇"
-
 DONATE_MSG="👋 maintaining gitleaks takes a lot of work so consider sponsoring me or donating a little something\n\e[36mhttps://github.com/sponsors/zricethezav\n\e[36mhttps://www.paypal.me/zricethezav\n"
 
-if [ "$GITHUB_EVENT_NAME" = "push" ]
-then
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG)
-elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]
-then 
-  git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG)
-fi
+# Use the base branch for pull requests and the "before" commit for pushes as the scan boundary.
+case "$GITHUB_EVENT_NAME" in
+ "push")         TARGET_REF="$INPUT_COMMIT_BEFORE" ;;
+ "pull_request") TARGET_REF="remotes/origin/$GITHUB_BASE_REF" ;;
+ *)              echo "Unsupported event type: $GITHUB_EVENT_NAME"; exit 1 ;;
+esac
+
+echo "Scanning commits back to $TARGET_REF"
+
+# Create list of commits since the target ref.
+git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" $TARGET_REF... > commit_list.txt
+
+echo running gitleaks "$(gitleaks --version) with the following command👇"
+echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG
+CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG)
 
 if [ $? -eq 1 ]
 then


### PR DESCRIPTION
Fixes https://github.com/zricethezav/gitleaks-action/issues/29

Limits the scan to commits since the GitHub event `before` field. This handles the case where multiple commits were included in the same push, but does not scan commits from older push events. 

The `push` behavior is now the same as the `pull_request` behavior, just using the `before` commit instead of the base ref.