### PR TITLE
Add option to specify output format of scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Gitleaks Action provides a simple way to run gitleaks in your CI/CD pipeline.
 
-
 ### Sample Workflow
-```
+
+``` yaml
 name: gitleaks
 
 on: [push,pull_request]
@@ -21,7 +21,8 @@ jobs:
 ```
 
 ### Using your own .gitleaks.toml configuration
-```
+
+``` yaml
 name: gitleaks
 
 on: [push,pull_request]
@@ -36,13 +37,37 @@ jobs:
       with:
         config-path: security/.gitleaks.toml
 ```
-    > The `config-path` is relative to your GitHub Worskpace
 
-### NOTE!!!
-You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1. 
+> The `config-path` is relative to your GitHub Workspace
 
-ex: 
+### generating a different report format
+
+``` yaml
+name: gitleaks
+
+on: [push,pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: gitleaks-action
+      uses: zricethezav/gitleaks-action@master
+      with:
+        format: JSON
 ```
+
+> The `format` can be one of `JSON, CSV, SARIF`.
+> The default is `SARIF`,  used for code scanning in Github.
+
+### NOTE
+
+You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1.
+
+ex:
+
+``` yaml
     steps:
     - uses: actions/checkout@v2
       with:
@@ -51,4 +76,4 @@ ex:
       uses: zricethezav/gitleaks-action@master
 ```
 
-using a fetch-depth of '0' clones the entire history. If you want to do a more efficient clone, use '2', but that is not guaranteed to work with pull requests.   
+using a fetch-depth of '0' clones the entire history. If you want to do a more efficient clone, use '2', but that is not guaranteed to work with pull requests.

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   format:
     description: 'report format'
     required: false
-    default: "SARIF"
+    default: SARIF
 outputs:
   result: # id of output
     description: 'Gitleaks log output'

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Path to config (relative to $GITHUB_WORKSPACE)'
     required: false
     default: '.github/.gitleaks.toml'
+  format:
+    description: 'report format'
+    required: false
+    default: "SARIF"
 outputs:
   result: # id of output
     description: 'Gitleaks log output'
@@ -18,3 +22,4 @@ runs:
   image: "Dockerfile"
   args:
     - ${{ inputs.config-path }}
+    - ${{ inputs.format }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 
 INPUT_CONFIG_PATH="$1"
 CONFIG=""
+INPUT_FILE_FORMAT="$2"
 
 # check if a custom config have been provided
 if [ -f "$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH" ]; then
@@ -17,10 +18,10 @@ then
   echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG
   CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG)
 elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]
-then 
+then
   git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG)
+  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt  $CONFIG
+  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt --format=$INPUT_FILE_FORMAT $CONFIG)
 fi
 
 if [ $? -eq 1 ]


### PR DESCRIPTION
This small PR adds the option to change the output of the report from the gitleaks scan.
I think it's useful to have SARIF as the default, as Github actions can upload this for code scanning.
I could spend more time on this to actually create the file, but this is a good first attempt hopefully!
Resolves issue #35 