### PR TITLE
Allow for gitleaks extra args and uploading report as an artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Gitleaks Action provides a simple way to run gitleaks in your CI/CD pipeline.
 
-
 ### Sample Workflow
+
 ```
 name: gitleaks
 
@@ -21,6 +21,7 @@ jobs:
 ```
 
 ### Using your own .gitleaks.toml configuration
+
 ```
 name: gitleaks
 
@@ -36,9 +37,11 @@ jobs:
       with:
         config-path: security/.gitleaks.toml
 ```
+
     > The `config-path` is relative to your GitHub Worskpace
 
 ### Use extra args to output report
+
 ```
 name: gitleaks
 
@@ -57,17 +60,15 @@ jobs:
 
 Related documentation: https://github.com/zricethezav/gitleaks#usage-and-options
 
-### NOTE!!!
-You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1.
+### Uploading output report as an artifact
 
 If you configure extra arguments so that there's an output file and you want the output file to be uploaded as an artifact, you must use `actions/upload-artifact` after the gitleaks-action step.
 
-ex: 
+ex:
+
 ```
-    steps:
+  steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: '0'
     - name: gitleaks-action
       uses: zricethezav/gitleaks-action@master
       with:
@@ -78,4 +79,19 @@ ex:
         path: gitleaks.json
 ```
 
-using a fetch-depth of '0' clones the entire history. If you want to do a more efficient clone, use '2', but that is not guaranteed to work with pull requests.   
+### NOTE!!!
+
+You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1.
+
+ex:
+
+```
+  steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: gitleaks-action
+      uses: zricethezav/gitleaks-action@master
+```
+
+using a fetch-depth of '0' clones the entire history. If you want to do a more efficient clone, use '2', but that is not guaranteed to work with pull requests.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
 ```
     > The `config-path` is relative to your GitHub Worskpace
 
-### Use extra args to output report and upload as an artifact
+### Use extra args to output report
 ```
 name: gitleaks
 
@@ -53,10 +53,6 @@ jobs:
       uses: zricethezav/gitleaks-action@master
       with:
         extra-args: -o gitleaks.json
-    - uses: actions/upload-artifact@v2
-      with:
-        name: gitleaks
-        path: gitleaks.json
 ```
 
 Related documentation: https://github.com/zricethezav/gitleaks#usage-and-options
@@ -74,6 +70,8 @@ ex:
         fetch-depth: '0'
     - name: gitleaks-action
       uses: zricethezav/gitleaks-action@master
+      with:
+        extra-args: -o gitleaks.json
     - uses: actions/upload-artifact@v2
       with:
         name: gitleaks

--- a/README.md
+++ b/README.md
@@ -38,8 +38,31 @@ jobs:
 ```
     > The `config-path` is relative to your GitHub Worskpace
 
+### Output report and upload as an artifact
+```
+name: gitleaks
+
+on: [push,pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: gitleaks-action
+      uses: zricethezav/gitleaks-action@master
+      with:
+        extra-args: -o gitleaks.json
+    - uses: actions/upload-artifact@v2
+      with:
+        name: gitleaks
+        path: gitleaks.json
+```
+
 ### NOTE!!!
-You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1. 
+You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1.
+
+If you configure extra arguments so that there's an output file and you want the output file to be uploaded as an artifact, you must use `actions/upload-artifact` after the gitleaks-action step.
 
 ex: 
 ```
@@ -49,6 +72,10 @@ ex:
         fetch-depth: '0'
     - name: gitleaks-action
       uses: zricethezav/gitleaks-action@master
+    - uses: actions/upload-artifact@v2
+      with:
+        name: gitleaks
+        path: gitleaks.json
 ```
 
 using a fetch-depth of '0' clones the entire history. If you want to do a more efficient clone, use '2', but that is not guaranteed to work with pull requests.   

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
 ```
     > The `config-path` is relative to your GitHub Worskpace
 
-### Output report and upload as an artifact
+### Use extra args to output report and upload as an artifact
 ```
 name: gitleaks
 
@@ -58,6 +58,8 @@ jobs:
         name: gitleaks
         path: gitleaks.json
 ```
+
+Related documentation: https://github.com/zricethezav/gitleaks#usage-and-options
 
 ### NOTE!!!
 You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Path to config (relative to $GITHUB_WORKSPACE)'
     required: false
     default: '.github/.gitleaks.toml'
+  extra-args:
+    description: 'Extra arguments to be passed onto gitleaks'
+    required: false
+    default: ''
 outputs:
   result: # id of output
     description: 'Gitleaks log output'
@@ -18,3 +22,4 @@ runs:
   image: "Dockerfile"
   args:
     - ${{ inputs.config-path }}
+    - ${{ inputs.extra-args }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 INPUT_CONFIG_PATH="$1"
+EXTRA_ARGS="$2"
 CONFIG=""
 
 # check if a custom config have been provided
@@ -14,13 +15,13 @@ DONATE_MSG="👋 maintaining gitleaks takes a lot of work so consider sponsoring
 
 if [ "$GITHUB_EVENT_NAME" = "push" ]
 then
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG)
+  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG $EXTRA_ARGS
+  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG $EXTRA_ARGS)
 elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]
 then 
   git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG)
+  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG $EXTRA_ARGS
+  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG $EXTRA_ARGS)
 fi
 
 if [ $? -eq 1 ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ if [ $? -eq 1 ]
 then
   GITLEAKS_RESULT=$(echo -e "\e[31m🛑 STOP! Gitleaks encountered leaks")
   echo "$GITLEAKS_RESULT"
-  echo "::set-output name=exitcode::$GITLEAKS_RESULT"
+  echo "::set-output name=exitcode::1"
   echo "----------------------------------"
   echo "$CAPTURE_OUTPUT"
   echo "::set-output name=result::$CAPTURE_OUTPUT"
@@ -38,7 +38,7 @@ then
 else
   GITLEAKS_RESULT=$(echo -e "\e[32m✅ SUCCESS! Your code is good to go!")
   echo "$GITLEAKS_RESULT"
-  echo "::set-output name=exitcode::$GITLEAKS_RESULT"
+  echo "::set-output name=exitcode::0"
   echo "------------------------------------"
   echo -e $DONATE_MSG
 fi


### PR DESCRIPTION
Our team wants to be able to control formatting and report output in order to export the findings to Defect Dojo.

By allowing for extra arguments, the user would be able to have full usage of the Gitleaks feature set.