### PR TITLE
Configure dependabot to help keep deps up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This could help reduce some of the human toil of keeping dependencies up to date, such as https://github.com/zricethezav/gitleaks-action/pull/41