### PR TITLE
gitleaks 8.7.2 support

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,10 +6,13 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: gitleaks-action with defaults
-        uses: zricethezav/gitleaks-action@master
-      - name: gitleaks-action with config
-        uses: zricethezav/gitleaks-action@master
-        with:
-          config-path: .gitleaks.yml
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: gitleaks-action with config
+      uses: zricethezav/gitleaks-action@master
+      with:
+        # test custom path for config
+        config-path: gitleaks.toml
+    - name: gitleaks-action with defaults will fail
+      uses: zricethezav/gitleaks-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM zricethezav/gitleaks:v7.4.0
+FROM zricethezav/gitleaks:v8.7.2
 
 LABEL "com.github.actions.name"="gitleaks-action"
 LABEL "com.github.actions.description"="runs gitleaks on push and pull request events"
 LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="purple"
 LABEL "repository"="https://github.com/zricethezav/gitleaks-action"
+
+# User 'root' is required to successfully modify the system `git` permissions so
+# that the GITHUB_WORKSPACE can be marked as safe, despite being owned by someone
+# else (i.e. a user outside of Docker).
+USER root
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 Gitleaks Action provides a simple way to run gitleaks in your CI/CD pipeline.
 
+This action should be used after a checkout. Be sure `actions/checkout` runs with the appropriate
+`fetch-depth` that you need:
+
+* `fetch-depth: 0` clones the entire history
+* `fetch-depth: 1`, the default, fetches only the most recent commit.
 
 ### Sample Workflow
 ```
@@ -17,7 +22,9 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
     - name: gitleaks-action
       uses: zricethezav/gitleaks-action@master
 ```
@@ -32,25 +39,12 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
     - name: gitleaks-action
       uses: zricethezav/gitleaks-action@master
       with:
         config-path: security/.gitleaks.toml
 ```
     > The `config-path` is relative to your GitHub Worskpace
-
-### NOTE!!!
-You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1. 
-
-ex: 
-```
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: '0'
-    - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@master
-```
-
-using a fetch-depth of '0' clones the entire history. If you want to do a more efficient clone, use '2', but that is not guaranteed to work with pull requests.   

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Gitleaks
-description: Run Gitleaks on Push and PR events
+description: Runs Gitleaks
 branding:
   color: purple
   icon: eye
@@ -7,7 +7,6 @@ inputs:
   config-path:
     description: 'Path to config (relative to $GITHUB_WORKSPACE)'
     required: false
-    default: '.github/.gitleaks.toml'
 outputs:
   result: # id of output
     description: 'Gitleaks log output'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ git config --global --add safe.directory "$GITHUB_WORKSPACE"
 extra_args=""
 
 # check if a custom config have been provided
-if [ ! -z "$1" ]; then
+if [ ! -z "${1-""}" ]; then
   extra_args="$extra_args --config $GITHUB_WORKSPACE/$1"
 fi
 

--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -104,6 +104,8 @@ title = "gitleaks config"
 	files = ['''^\.?gitleaks.toml$''',
 	'''(.*?)(jpg|gif|doc|pdf|bin)$''',
 	'''(go.mod|go.sum)$''']
+	# These commits contain fake secrets from early test/dev of the action.
+	# Ignoring them allows the action to pass.
 	commits = [
 		'20fc1291b984a8374b5d19a4442645e7aae506d6',
 		'b5714cec629d710b7880a4158a8809f1cfee8448',

--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -104,3 +104,9 @@ title = "gitleaks config"
 	files = ['''^\.?gitleaks.toml$''',
 	'''(.*?)(jpg|gif|doc|pdf|bin)$''',
 	'''(go.mod|go.sum)$''']
+	commits = [
+		'20fc1291b984a8374b5d19a4442645e7aae506d6',
+		'b5714cec629d710b7880a4158a8809f1cfee8448',
+		'e1a5408dec0df17125c6a2e4bc57fa56e1296e7d',
+		'e7150a87e012d353a2c2e1ca8ec832b036dbde40',
+	]


### PR DESCRIPTION
Hi @zricethezav, thanks for your work on gitleaks. This updates this action to work with the latest version of gitleaks (8.7.1), and does some minor cleanup:

    * Supports actions other than push/pr
    * Works around the git permission issue caused by the fix for CVE-2022-24765
    * Cleans up docs for actions/checkout@v3
    * Drops default config path (was .github/.gitleaks.toml)
    * More likely to error than silently fail when misconfigured