### PR TITLE
fix: multi line gitleaks output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,10 @@ then
   echo "::set-output name=exitcode::$GITLEAKS_RESULT"
   echo "----------------------------------"
   echo "$CAPTURE_OUTPUT"
+  # https://trstringer.com/github-actions-multiline-strings/#option-1---string-substitution
+  CAPTURE_OUTPUT="${CAPTURE_OUTPUT//'%'/'%25'}"
+  CAPTURE_OUTPUT="${CAPTURE_OUTPUT//$'\n'/'%0A'}"
+  CAPTURE_OUTPUT="${CAPTURE_OUTPUT//$'\r'/'%0D'}"
   echo "::set-output name=result::$CAPTURE_OUTPUT"
   echo "----------------------------------"
   echo -e $DONATE_MSG


### PR DESCRIPTION
This action exposes the gitleaks output through the `result` property. Since the output is a multi line string setting the property does not work correctly. This commit adds string substitution according to

https://trstringer.com/github-actions-multiline-strings/#option-1---string-substitution

to properly propagate the output.

I've tested the string substitution with the following workflow:

```yaml
name: GitLeaks Check

on:
  pull_request:

jobs:
  gitleaks:
    name: Running GitLeaks Check
    runs-on: ubuntu-latest
    steps:
      - name: Checking out repository
        uses: actions/checkout@v2
        with:
          fetch-depth: "0"

      - name: Running gitleaks
        id: gitleaks
        uses: dennis-tra/gitleaks-action@master
        with:
          config-path: .gitleaks.toml
        continue-on-error: ${{ github.event_name == 'pull_request' }}

      - name: Comment on Pull Request if Gitleaks found something
        uses: actions/github-script@0.9.0
        if: github.event_name == 'pull_request' && steps.gitleaks.outcome == 'failure'
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          script: |
            const output = `#### 🚨 @${{ github.actor }}: Gitleaks Found an Issue 🚨


            <details>
            <summary>Show Gitleaks Output</summary>

            \`\`\`
            ${{ steps.gitleaks.outputs.result }}
            \`\`\`
            </details>
            `;

            github.issues.createComment({
              issue_number: context.issue.number,
              owner: context.repo.owner,
              repo: context.repo.repo,
              body: output
            })
```

The `<details>` block now shows something like:

```
{
	"line": "REDACTED",
	"lineNumber": 1,
	"offender": "REDACTED",
	"commit": "4cb0d316e93010122dce08ac7268789ae804aa6d",
	"repo": "workspace",
	"repoURL": "",
	"leakURL": "",
	"rule": "AWS",
	"commitMessage": "Merge b3a2619a2b8c277c00ba62ba098b7a9210daaa10 into ef28300ab143eaf3a1f988d22cb8ad34924517b1
",
        ...
	"file": "test.txt",
	"date": "2022-05-24T08:16:56Z",
	"tags": ""
}
{
	"line": "REDACTED",
	"lineNumber": 1,
	"offender": "REDACTED",
	"commit": "b3a2619a2b8c277c00ba62ba098b7a9210daaa10",
	"repo": "workspace",
	"repoURL": "",
	"leakURL": "",
	"rule": "AWS",
	"commitMessage": "test commit
",
        ...
	"file": "test.txt",
	"date": "2022-05-24T10:16:45+02:00",
	"tags": ""
}
```

Previously, this block only contained `{`.

The substitution is not perfect as the `commitMessage` property ends with a `\n` and this gets substituted as well. Good enough for my purposes though 👍