### PR TITLE
Exclude merge commits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ then
   CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG)
 elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]
 then 
-  git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt
+  git --git-dir="$GITHUB_WORKSPACE/.git" log --no-merges --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt
   echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG
   CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG)
 fi


### PR DESCRIPTION
When looking for leaks on a PR branch, `merge commits` should be excluded. People often merge main into their PR branch multiple times before they merge their PR eventually. If `merge commits` aren't excluded, it's possible that leaks that aren't on the PR branch are identified as issues, which can block PRs from being merged (it's configured as a require check).

I've tested this change for a private repo and it worked well. Without the change, `gitleaks detect` found issues. With this change, it found no issues.