### PR TITLE
fix URLs in summary for scheduled workflows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,24 +46,7 @@ if (!supportedEvents.includes(eventType)) {
 }
 
 // Determine if the github user is an individual or an organization
-let githubUsername = "";
-
-// eventJSON.repository is undefined for scheduled events
-if (eventType == "schedule") {
-  githubUsername = process.env.GITHUB_REPOSITORY_OWNER;
-  eventJSON.repository = {
-    owner: {
-      login: process.env.GITHUB_REPOSITORY_OWNER,
-    },
-    full_name: process.env.GITHUB_REPOSITORY,
-  };
-  let repoName = process.env.GITHUB_REPOSITORY;
-  repoName = repoName.replace(`${process.env.GITHUB_REPOSITORY_OWNER}/`, "");
-  // update repo name
-  process.env.GITHUB_REPOSITORY = repoName;
-} else {
-  githubUsername = eventJSON.repository.owner.login;
-}
+const githubUsername = eventJSON.repository.owner.login;
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,


### PR DESCRIPTION
Fixes #121.

I tested privately that on scheduled workflows (i.e. with `schedule` event type), the `repository` property is set the same as for other event types.

I therefore removed the `if` block that overwrites `repository` and omits `html_url`.