### PR TITLE
Add support for "merge_group" event

### DIFF
--- a/src/gitleaks.js
+++ b/src/gitleaks.js
@@ -100,7 +100,7 @@ async function Scan(gitleaksEnableUploadArtifact, scanInfo, eventType) {
     "--log-level=debug",
   ];
 
-  if (eventType == "push") {
+  if (eventType == "push" || eventType == "merge_group") {
     if (scanInfo.baseRef == scanInfo.headRef) {
       // if base and head refs are the same, use `--log-opts=-1` to
       // scan only one commit

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ let eventJSON = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
 // Examples of event types: "workflow_dispatch", "push", "pull_request", etc
 const eventType = process.env.GITHUB_EVENT_NAME;
 const supportedEvents = [
+  "merge_group",
   "push",
   "pull_request",
   "workflow_dispatch",
@@ -121,7 +122,7 @@ octokit
 async function start() {
   // validate key first
 
-  // keygen payment method is getting declined... disable this check for now. 
+  // keygen payment method is getting declined... disable this check for now.
   // if (shouldValidate) {
   //   core.debug(
   //     `eventJSON.repository.full_name: ${eventJSON.repository.full_name}`
@@ -184,6 +185,18 @@ async function start() {
       gitleaksEnableUploadArtifact,
       octokit,
       eventJSON,
+      eventType
+    );
+  } else if (eventType === "merge_group") {
+    scanInfo = {
+      gitleaksPath: gitleaksPath,
+      baseRef: eventJSON.merge_group.base_sha,
+      headRef: eventJSON.merge_group.head_sha,
+    };
+
+    exitCode = await gitleaks.Scan(
+      gitleaksEnableUploadArtifact,
+      scanInfo,
       eventType
     );
   }


### PR DESCRIPTION
This allows using Gitleaks with GitHub Merge Queues.

See the following links for more information about the feature:
- [GitHub Merge Queues description][1]
- [`merge_group` webhook event][2]

Fixes #118

[1]: https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
[2]: https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group