### PR TITLE
Bump checkout action

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -10,7 +10,7 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/gitleaks-action-HEAD.yml
+++ b/.github/workflows/gitleaks-action-HEAD.yml
@@ -16,7 +16,7 @@ jobs:
     name: gitleaks-action-HEAD
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: master

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
This PR bumps `actions/checkout` to latest released version `v5`.