### PR TITLE
chore: migrate to Node 24 runtime (v3)

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -10,10 +10,10 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}

--- a/.github/workflows/gitleaks-action-HEAD.yml
+++ b/.github/workflows/gitleaks-action-HEAD.yml
@@ -16,7 +16,7 @@ jobs:
     name: gitleaks-action-HEAD
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: master

--- a/README.md
+++ b/README.md
@@ -34,14 +34,37 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }} # Only required for Organizations, not personal accounts.
 ```
+
+## Migrating from v2 to v3
+
+**v3 migrates the GitHub Actions runtime from Node 20 to Node 24.** There are no changes to inputs, outputs, or behavior. The upgrade is a one-line change in your workflow file:
+
+```diff
+-      - uses: gitleaks/gitleaks-action@v2
++      - uses: gitleaks/gitleaks-action@v3
+```
+
+You should also update `actions/checkout` to v6 (the Node 24 release):
+
+```diff
+-      - uses: actions/checkout@v3  # or @v4
++      - uses: actions/checkout@v6
+```
+
+**Why v3?** GitHub is deprecating Node 20 for GitHub Actions:
+
+- **June 2, 2026:** GitHub switches the runner default to Node 24. Workflows using Node 20 actions (including `gitleaks-action@v2`) will require `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` to keep running. Without this opt-out, Node 20 actions will fail.
+- **September 16, 2026:** Node 20 is removed from GitHub-hosted runners entirely. `gitleaks-action@v2` will stop working regardless of any opt-out flag.
+
+**Runner requirements:** v3 requires GitHub Actions runner v2.327.1 or later. All current GitHub-hosted runners meet this requirement. Self-hosted runner operators should update their runner before upgrading to v3.
 
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ branding:
   color: "purple"
 description: run gitleaks on push and pull-request events
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@actions/artifact": "^2.3.2",
         "@actions/cache": "^4.0.0",
-        "@actions/core": "1.10.0",
+        "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",
         "@actions/tool-cache": "^1.7.2",
         "@octokit/rest": "^18.12.0"
@@ -83,7 +83,7 @@
         "semver": "^6.3.1"
       }
     },
-    "node_modules/@actions/cache/node_modules/@actions/core": {
+    "node_modules/@actions/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
@@ -91,23 +91,6 @@
       "dependencies": {
         "@actions/exec": "^1.1.1",
         "@actions/http-client": "^2.0.1"
-      }
-    },
-    "node_modules/@actions/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
-      "dependencies": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@actions/core/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@actions/exec": {
@@ -1855,33 +1838,15 @@
         "@azure/storage-blob": "^12.13.0",
         "@protobuf-ts/plugin": "^2.9.4",
         "semver": "^6.3.1"
-      },
-      "dependencies": {
-        "@actions/core": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-          "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
-          "requires": {
-            "@actions/exec": "^1.1.1",
-            "@actions/http-client": "^2.0.1"
-          }
-        }
       }
     },
     "@actions/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "requires": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
       }
     },
     "@actions/exec": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@actions/artifact": "^2.3.2",
     "@actions/cache": "^4.0.0",
-    "@actions/core": "1.10.0",
+    "@actions/core": "^1.11.1",
     "@actions/exec": "^1.1.1",
     "@actions/tool-cache": "^1.7.2",
     "@octokit/rest": "^18.12.0"


### PR DESCRIPTION
## Summary

Migrates `gitleaks-action` from the Node 20 GitHub Actions runtime to Node 24, released as **v3.0.0**.

- `action.yml`: `using: "node20"` -> `using: "node24"`
- `@actions/core` bumped from `1.10.0` to `1.11.1` for Node 24 compatibility
- `dist/index.js` rebuilt via `ncc`
- Workflow examples updated: `actions/checkout@v3`/`@v4` -> `@v6`, `gitleaks-action@v2` -> `@v3`
- `README.md` updated with v3 migration guide and Node 20 deprecation timeline

## Why v3 (major bump)?

Node 24 requires runner v2.327.1+. Self-hosted runner operators who haven't updated would break silently if we shipped this under the existing `@v2` tag. A major version bump gives all consumers explicit opt-in.

## Node 20 deprecation timeline

| Date | What happens |
|---|---|
| **June 2, 2026** | GitHub flips runner default to Node 24. Node 20 actions require `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` to keep running. |
| **September 16, 2026** | Node 20 removed from GitHub-hosted runners. `gitleaks-action@v2` stops working entirely. |

## After merge

1. Tag `v3.0.0` and create a GitHub Release with migration notes
2. Create rolling `v3` tag pointing to the same commit
3. Open a GitHub Discussion or Issue announcing v2 deprecation
4. Update consumer repos (`gitleaks/gitleaks`, `gitleaks/.github`, `gitleaks/website`) to reference `@v3`

## Test plan

- [ ] CI passes on this PR (the `gitleaks-action-HEAD.yml` workflow tests the action from `./`, confirming it runs on Node 24)
- [ ] Verify `dist/index.js` bundle is correct (rebuilt with `npx ncc build src/index.js -o dist`)
- [ ] After tagging v3.0.0, verify a consumer workflow using `gitleaks/gitleaks-action@v3` runs successfully

Made with [Cursor](https://cursor.com)