### PR TITLE
chore: supply-chain hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default — every PR requires at least one org member review.
+*                          @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+
+# Supply-chain critical paths (same reviewers, but called out
+# explicitly so they survive if the default is ever loosened).
+/action.yml                @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+/dist/                     @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+/package.json              @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+/package-lock.json         @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+/.github/                  @bryanbeverly @dustin-decker @dxa4481 @zricethezav

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions-sdk:
+        patterns:
+          - "@actions/*"
+      all-other:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -10,10 +10,10 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v3
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}

--- a/.github/workflows/gitleaks-action-HEAD.yml
+++ b/.github/workflows/gitleaks-action-HEAD.yml
@@ -16,7 +16,7 @@ jobs:
     name: gitleaks-action-HEAD
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: master

--- a/.github/workflows/verify-dist.yml
+++ b/.github/workflows/verify-dist.yml
@@ -1,0 +1,40 @@
+name: Verify dist
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "dist/**"
+  push:
+    branches: [master]
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "dist/**"
+
+jobs:
+  verify:
+    name: Verify dist/ matches source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+
+      - run: npm ci
+
+      - run: npx ncc build src/index.js -o dist
+
+      - name: Check for uncommitted changes to dist/
+        run: |
+          if [ -n "$(git diff --name-only dist/)" ]; then
+            echo "::error::dist/ is out of date. Run 'npm ci && npx ncc build src/index.js -o dist' and commit the result."
+            git diff --stat dist/
+            exit 1
+          fi
+          echo "dist/ is up to date."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,25 @@
+# Releasing gitleaks-action
+
+## Semver tags (immutable)
+
+Semver tags like `v3.0.0`, `v3.1.0` are **immutable** — once pushed, they must never be force-updated or deleted. Tag protection rules enforce this.
+
+## Rolling major tags
+
+Rolling tags like `v3` point to the latest patch in their major line. After creating a new semver tag, update the rolling tag:
+
+```bash
+git tag -fa v3 v3.x.y
+git push origin v3 --force
+```
+
+Only gitleaks org members should update rolling tags.
+
+## Release checklist
+
+1. Ensure `dist/` is up to date: `npm ci && npx ncc build src/index.js -o dist`
+2. Verify the `verify-dist` CI check passes
+3. Merge the PR to `master`
+4. Create the semver tag: `git tag v3.x.y && git push origin v3.x.y`
+5. Update the rolling tag (see above)
+6. Create a GitHub Release from the semver tag with changelog notes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| v3.x    | Yes       |
+| v2.x    | Deprecated — no further updates (Node 20 EOL) |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in gitleaks-action, please report it responsibly:
+
+1. **Do not open a public issue.**
+2. Use [GitHub's private vulnerability reporting](https://github.com/gitleaks/gitleaks-action/security/advisories/new) to submit your report directly.
+3. Include a description of the vulnerability, steps to reproduce, and any relevant logs or screenshots.
+
+## Scope
+
+This policy covers `gitleaks-action` (this repository). For vulnerabilities in the `gitleaks` CLI itself, please report them at [gitleaks/gitleaks](https://github.com/gitleaks/gitleaks/security/advisories/new).

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "@actions/artifact": "^2.3.2",
-    "@actions/cache": "^4.0.0",
-    "@actions/core": "^1.11.1",
-    "@actions/exec": "^1.1.1",
-    "@actions/tool-cache": "^1.7.2",
-    "@octokit/rest": "^18.12.0"
+    "@actions/artifact": "2.3.2",
+    "@actions/cache": "4.0.3",
+    "@actions/core": "1.11.1",
+    "@actions/exec": "1.1.1",
+    "@actions/tool-cache": "1.7.2",
+    "@octokit/rest": "18.12.0"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.34.0"
+    "@vercel/ncc": "0.34.0"
   },
   "license": "SEE LICENSE IN COMMERCIAL-LICENSE.txt",
   "name": "gitleaks-github-action"


### PR DESCRIPTION
## Summary

Adds supply-chain hardening measures to reduce the attack surface for gitleaks-action, addressing the same class of risk that led to the [tj-actions/changed-files compromise (CVE-2025-30066)](https://nvd.nist.gov/vuln/detail/CVE-2025-30066).

### Changes

- **Dependency pinning** — Remove `^` ranges in `package.json`, pin to exact resolved versions
- **SHA-pinned workflow references** — Pin `actions/checkout` and `gitleaks/gitleaks-action` to commit SHAs with version comments in example and CI workflows
- **Reproducible build verification** — New `verify-dist` CI workflow that rebuilds `dist/` from source and fails if it doesn't match the committed bundle
- **CODEOWNERS** — Default owner (all 4 org members) plus explicit protection on `action.yml`, `dist/`, package files, and `.github/`
- **Dependabot** — Weekly npm and GitHub Actions dependency updates, with `@actions/*` SDK deps grouped
- **SECURITY.md** — Vulnerability disclosure policy pointing to GitHub private reporting
- **RELEASING.md** — Documents the immutable semver tag vs rolling major tag process

### What this does NOT change

- No changes to the action's runtime behavior, inputs, or outputs
- Branch protection was already enabled separately (require PR reviews, CODEOWNER approval, no force push)

### Companion to

- v3.0.0 release (PR #215, merged) — Node 24 migration
- Tag protection rules will be configured via repo settings after this PR merges

## Test plan

- [x] `verify-dist` workflow runs and passes on this PR
- [ ] CODEOWNERS triggers review requests correctly
- [ ] Dependabot begins opening PRs after merge

Made with [Cursor](https://cursor.com)